### PR TITLE
Support railway/heroku provided port

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,10 @@ func main() {
 		host = "0.0.0.0"
 	}
 	if port == "" {
-		port = "8080"
+		port = os.Getenv("PORT")
+		if port == "" {
+			port = "8080"
+		}
 	}
 
 	if tlsCert != "" && tlsKey != "" {


### PR DESCRIPTION
As mentioned in the [documentation](https://docs.railway.app/guides/public-networking), railway will provide and use the `PORT` environment variable by default. If this compatibility issue is not provided, you will need to manually add `PORT: 8080` when deploying to railway. And heroku even can't define the `PORT` variable.

#156 #164