### PR TITLE
feat: Codex CLI 适配 — Responses 真流式 + 思维链 + 缓存模拟

### DIFF
--- a/API.md
+++ b/API.md
@@ -197,6 +197,67 @@ curl --location 'http://你的服务器ip:8080/v1/responses' \
 }'
 ```
 
+### Responses 流式事件序列
+
+开启 `stream: true` 后，服务端以 SSE 返回以下事件：
+
+```
+event: response.created
+data: {"type":"response.created","response":{...,"status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning",...}}
+
+event: response.reasoning_text.delta     ← 思维链（仅思考模型）
+data: {"type":"response.reasoning_text.delta","delta":"..."}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"type":"message",...}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"..."}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"type":"reasoning","status":"completed",...}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"type":"message","status":"completed",...}}
+
+event: response.completed
+data: {"type":"response.completed","response":{...,"usage":{...}}}
+```
+
+### Responses 参数
+
+| 参数 | 类型 | 说明 |
+|---|---|---|
+| `reasoning.effort` | string | 思考强度：`none` / `minimal` / `low` / `medium` / `high` / `xhigh` / `max`，映射到 ChatGPT 上游的 `low` / `medium` / `high` |
+| `store` | bool | 是否存储响应（默认 false） |
+| `stream_options` | object | 流式选项 |
+
+### Usage 响应字段
+
+```json
+{
+  "usage": {
+    "input_tokens": 100,
+    "input_tokens_details": { "cached_tokens": 80, "cache_write_tokens": 20 },
+    "output_tokens": 50,
+    "output_tokens_details": { "reasoning_tokens": 30 },
+    "total_tokens": 150
+  }
+}
+```
+
+注意：`cached_tokens` / `cache_write_tokens` 为**模拟值**（按文本指纹 + 5 分钟 TTL），ChatGPT 上游不返回真实缓存数据。
+
+### 响应耗时信息
+
+流式 `response.completed` 事件附带耗时字段：
+
+- `ms_since_start`：请求开始到完成的毫秒数
+- `ms_ttft`：请求开始到首个 output_text delta 的毫秒数（首字延迟）
+
 ## 模型列表
 
 ```bash

--- a/conversion/requests/chatgpt/convert.go
+++ b/conversion/requests/chatgpt/convert.go
@@ -26,21 +26,24 @@ func ConvertAPIRequest(api_request official_types.APIRequest, account *accounts.
 
 	// ── 映射 OpenAI 标准生成参数到 ChatGPT ──
 
-	// reasoning_effort → ThinkingEffort (直接映射)
+	// reasoning_effort → ThinkingEffort（OpenAI 7 档 → ChatGPT 3 档）
 	effort := strings.ToLower(strings.TrimSpace(api_request.ReasoningEffort))
 	if effort == "" {
-		// 兼容 Responses API reasoning.effort
 		effort = "standard"
 	}
 	switch effort {
+	case "none", "minimal":
+		chatgpt_request.ThinkingEffort = "low"
 	case "low":
 		chatgpt_request.ThinkingEffort = "low"
 	case "medium", "standard":
-		chatgpt_request.ThinkingEffort = "standard"
+		chatgpt_request.ThinkingEffort = "medium"
 	case "high":
 		chatgpt_request.ThinkingEffort = "high"
+	case "xhigh", "max":
+		chatgpt_request.ThinkingEffort = "high"
 	default:
-		chatgpt_request.ThinkingEffort = "standard"
+		chatgpt_request.ThinkingEffort = "medium"
 	}
 
 	// response_format: 通过 system prompt 注入指令

--- a/internal/handler/cache.go
+++ b/internal/handler/cache.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// cacheTracker simulates prompt-caching metrics per conversation. ChatGPT
+// Web does not expose real caching, so we fingerprint text blocks and report
+// "cache_write" on first sight and "cached" on reuse. Design ported from
+// D:/Go/claude2api/handlers/cache.go.
+type cacheTracker struct {
+	mu   sync.Mutex
+	seen map[string]time.Time // fingerprint -> first seen
+	ttl  time.Duration
+}
+
+var globalCacheTracker = &cacheTracker{
+	seen: make(map[string]time.Time),
+	ttl:  5 * time.Minute,
+}
+
+// estTokens returns a rough token count (~4 chars/token).
+func estTokens(text string) int {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return 0
+	}
+	n := len(text) / 4
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// cacheFP derives a stable key for a content block.
+func cacheFP(part string) string {
+	return part
+}
+
+// record processes the request text blocks and returns (cacheWriteTokens, cachedTokens).
+// Return order is creation-first so the public RecordCache matches the
+// test expectations: first sight yields cache_write > 0, reuse yields cached > 0.
+func (t *cacheTracker) record(conversationID, instructions, input string) (cacheWriteTokens, cachedTokens int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.gc()
+
+	type block struct {
+		fp     string
+		tokens int
+	}
+	var blocks []block
+	if instructions != "" {
+		blocks = append(blocks, block{cacheFP("instructions:" + instructions), estTokens(instructions)})
+	}
+	if input != "" {
+		blocks = append(blocks, block{cacheFP("input:" + input), estTokens(input)})
+	}
+
+	for _, b := range blocks {
+		if b.tokens == 0 {
+			continue
+		}
+		if _, ok := t.seen[b.fp]; ok {
+			cachedTokens += b.tokens
+		} else {
+			cacheWriteTokens += b.tokens
+			t.seen[b.fp] = time.Now()
+		}
+	}
+	return
+}
+
+// gc evicts expired fingerprints.
+func (t *cacheTracker) gc() {
+	now := time.Now()
+	for fp, seen := range t.seen {
+		if now.Sub(seen) > t.ttl {
+			delete(t.seen, fp)
+		}
+	}
+}
+
+// RecordCache is the package-level entry point.
+// Returns (cacheWriteTokens, cachedTokens) — creation first, matching the
+// claude2api convention and the cacheTracker.record implementation.
+func RecordCache(conversationID, instructions, input string) (cacheWriteTokens, cachedTokens int) {
+	return globalCacheTracker.record(conversationID, instructions, input)
+}

--- a/internal/handler/cache_test.go
+++ b/internal/handler/cache_test.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheTrackerFirstSeenIsCreation(t *testing.T) {
+	ct := &cacheTracker{seen: make(map[string]time.Time), ttl: 5 * time.Minute}
+	written, cached := ct.record("conv1", "system instructions", "user input")
+	if written == 0 {
+		t.Fatalf("expected cache_write_tokens > 0 on first sight, got %d", written)
+	}
+	if cached != 0 {
+		t.Fatalf("expected cached_tokens = 0 on first sight, got %d", cached)
+	}
+}
+
+func TestCacheTrackerSecondSeenIsRead(t *testing.T) {
+	ct := &cacheTracker{seen: make(map[string]time.Time), ttl: 5 * time.Minute}
+	ct.record("conv1", "system instructions", "user input")
+	written, cached := ct.record("conv1", "system instructions", "user input")
+	if cached == 0 {
+		t.Fatalf("expected cached_tokens > 0 on reuse, got %d", cached)
+	}
+	if written != 0 {
+		t.Fatalf("expected cache_write_tokens = 0 on reuse, got %d", written)
+	}
+}
+
+func TestCacheTrackerEmptyInputIsNoop(t *testing.T) {
+	ct := &cacheTracker{seen: make(map[string]time.Time), ttl: 5 * time.Minute}
+	written, cached := ct.record("conv1", "", "")
+	if cached != 0 || written != 0 {
+		t.Fatalf("expected zero cache for empty input, got cached=%d written=%d", cached, written)
+	}
+}

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -390,7 +390,7 @@ func (h *ChatHandler) Responses(c *gin.Context) {
 	}
 
 	output_tokens := util.CountToken(full_response)
-	responsesResponse := officialtypes.NewResponsesResponse(full_response, input_tokens, output_tokens, reqModel)
+	responsesResponse := officialtypes.NewResponsesResponse(full_response, "", input_tokens, output_tokens, 0, 0, 0, reqModel)
 	if !responsesRequest.Stream || !h.cfg.StreamMode {
 		c.JSON(200, responsesResponse)
 		return

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"fmt"
 	"io"
-"net/http"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"aurora/httpclient/bogdanfinn"
@@ -320,53 +321,24 @@ func (h *ChatHandler) Responses(c *gin.Context) {
 		reqModel = "auto"
 	}
 
-	response, wsConn, _, status, err := conversationClientOrder(&client, account, translated_request, proxyUrl, false, clientState, h.accountPool)
-	if err != nil {
-		c.JSON(status, gin.H{"error": gin.H{
-			"message": err.Error(),
-			"type":    "request_conversion_error",
-			"param":   "model",
-			"code":    "request_conversion_error",
-		}})
-		return
+	// 提取 instructions / input 用于缓存模拟
+	var instructions string
+	var inputTextParts []string
+	for _, msg := range original_request.Messages {
+		if msg.Role == "system" {
+			instructions += msg.Text()
+		} else {
+			inputTextParts = append(inputTextParts, msg.Text())
+		}
 	}
-	defer response.Body.Close()
-	if chatgpt.Handle_request_error(c, response) {
-		if wsConn != nil {
-			wsConn.Close()
-			wsConn = nil
-		}
-		return
-	}
+	inputText := strings.Join(inputTextParts, "\n")
+	cacheWriteTokens, cachedTokens := RecordCache(translated_request.ConversationID, instructions, inputText)
 
-	var full_response string
-	for i := h.cfg.MaxContinueCount; i > 0; i-- {
-		var continue_info *chatgpt.ContinueInfo
-		var response_part string
-		result := chatgpt.HandlerDetailedWithOptions(c, response, client, account, uid, translated_request, false, reqModel, chatgpt.HandlerDetailedOptions{
-			Websocket:   wsConn,
-			ClientState: clientState,
-		})
-		wsConn = nil
-		response_part, continue_info = result.Text, result.Continue
-		full_response += response_part
-		parentMessageID := result.ParentMessageID
-		if continue_info != nil {
-			parentMessageID = continue_info.ParentID
-		}
-		clientState.NoteTurnResult(result.ConversationID, parentMessageID)
-		if result.ConversationID != "" {
-			h.sessions.Register(result.ConversationID, clientState)
-		}
-		if continue_info == nil {
-			break
-		}
-		translated_request.Messages = nil
-		translated_request.Action = "continue"
-		translated_request.ConversationID = continue_info.ConversationID
-		translated_request.ParentMessageID = continue_info.ParentID
+	streamRequested := responsesRequest.Stream && h.cfg.StreamMode
 
-		response, wsConn, _, status, err = conversationClientOrder(&client, account, translated_request, proxyUrl, false, clientState, h.accountPool)
+	// 非流式路径：保持原有行为，使用新的 NewResponsesResponse 签名（含 reasoning + cache）
+	if !streamRequested {
+		response, wsConn, _, status, err := conversationClientOrder(&client, account, translated_request, proxyUrl, false, clientState, h.accountPool)
 		if err != nil {
 			c.JSON(status, gin.H{"error": gin.H{
 				"message": err.Error(),
@@ -384,26 +356,222 @@ func (h *ChatHandler) Responses(c *gin.Context) {
 			}
 			return
 		}
-	}
-	if c.Writer.Status() != 200 {
-		return
-	}
 
-	output_tokens := util.CountToken(full_response)
-	responsesResponse := officialtypes.NewResponsesResponse(full_response, "", input_tokens, output_tokens, 0, 0, 0, reqModel)
-	if !responsesRequest.Stream || !h.cfg.StreamMode {
+		var full_response string
+		var full_thinking string
+		var conversationID string
+		for i := h.cfg.MaxContinueCount; i > 0; i-- {
+			var continue_info *chatgpt.ContinueInfo
+			result := chatgpt.HandlerDetailedWithOptions(c, response, client, account, uid, translated_request, false, reqModel, chatgpt.HandlerDetailedOptions{
+				Websocket:   wsConn,
+				ClientState: clientState,
+			})
+			wsConn = nil
+			full_response += result.Text
+			full_thinking += result.ThinkingText
+			parentMessageID := result.ParentMessageID
+			continue_info = result.Continue
+			if continue_info != nil {
+				parentMessageID = continue_info.ParentID
+			}
+			clientState.NoteTurnResult(result.ConversationID, parentMessageID)
+			if result.ConversationID != "" {
+				conversationID = result.ConversationID
+				h.sessions.Register(conversationID, clientState)
+			}
+			if continue_info == nil {
+				break
+			}
+			translated_request.Messages = nil
+			translated_request.Action = "continue"
+			translated_request.ConversationID = continue_info.ConversationID
+			translated_request.ParentMessageID = continue_info.ParentID
+
+			response, wsConn, _, status, err = conversationClientOrder(&client, account, translated_request, proxyUrl, false, clientState, h.accountPool)
+			if err != nil {
+				c.JSON(status, gin.H{"error": gin.H{
+					"message": err.Error(),
+					"type":    "request_conversion_error",
+					"param":   "model",
+					"code":    "request_conversion_error",
+				}})
+				return
+			}
+			defer response.Body.Close()
+			if chatgpt.Handle_request_error(c, response) {
+				if wsConn != nil {
+					wsConn.Close()
+					wsConn = nil
+				}
+				return
+			}
+		}
+		if c.Writer.Status() != 200 {
+			return
+		}
+
+		output_tokens := util.CountToken(full_response)
+		reasoning_tokens := util.CountToken(full_thinking)
+		responsesResponse := officialtypes.NewResponsesResponse(full_response, full_thinking, input_tokens, output_tokens, reasoning_tokens, cachedTokens, cacheWriteTokens, reqModel)
 		c.JSON(200, responsesResponse)
 		return
 	}
 
+	// ── 流式路径 ──
+	startTime := time.Now()
+	respID := "resp_" + uuid.NewString()
+	reasoningItemID := "rs_" + uuid.NewString()
+	messageItemID := "msg_" + uuid.NewString()
+
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
-	c.String(200, "event: response.created\ndata: "+officialtypes.ResponsesCreated(responsesResponse)+"\n\n")
-	c.String(200, "event: response.output_text.delta\ndata: "+officialtypes.ResponsesTextDelta(full_response)+"\n\n")
-	c.String(200, "event: response.completed\ndata: "+officialtypes.ResponsesCompleted(responsesResponse)+"\n\n")
-	c.String(200, "data: [DONE]\n\n")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, _ := c.Writer.(http.Flusher)
+
+	// response.created
+	c.Writer.WriteString("event: response.created\ndata: " + responsesCreatedEvent(respID, reqModel) + "\n\n")
+	// output_item.added (reasoning, output_index 0)
+	c.Writer.WriteString("event: response.output_item.added\ndata: " + responsesOutputItemAddedEvent(0, reasoningItemID, "reasoning") + "\n\n")
+	// output_item.added (message, output_index 1)
+	c.Writer.WriteString("event: response.output_item.added\ndata: " + responsesOutputItemAddedEvent(1, messageItemID, "message") + "\n\n")
+	if flusher != nil {
+		c.Writer.WriteHeader(200)
+		flusher.Flush()
+	}
+
+	response, wsConn, _, _, err := conversationClientOrder(&client, account, translated_request, proxyUrl, true, clientState, h.accountPool)
+	if err != nil {
+		c.Writer.WriteString("event: response.failed\ndata: " + responsesFailedEvent(err.Error()) + "\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return
+	}
+	defer response.Body.Close()
+	if chatgpt.Handle_request_error(c, response) {
+		if wsConn != nil {
+			wsConn.Close()
+			wsConn = nil
+		}
+		c.Writer.WriteString("event: response.failed\ndata: " + responsesFailedEvent("upstream error") + "\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return
+	}
+
+	var full_response string
+	var full_thinking string
+	var conversationID string
+	ttftSet := false
+	var ttftMs int64
+
+	for i := h.cfg.MaxContinueCount; i > 0; i-- {
+		var continue_info *chatgpt.ContinueInfo
+		result := chatgpt.HandlerDetailedWithOptions(c, response, client, account, uid, translated_request, true, reqModel, chatgpt.HandlerDetailedOptions{
+			Websocket:   wsConn,
+			ClientState: clientState,
+		})
+		wsConn = nil
+		full_response += result.Text
+		full_thinking += result.ThinkingText
+
+		// 思维链增量
+		if result.ThinkingText != "" {
+			reasoningEvt := officialtypes.ResponsesReasoningDeltaEvent{
+				Type:         "response.reasoning_text.delta",
+				ItemID:       reasoningItemID,
+				OutputIndex:  0,
+				ContentIndex: 0,
+				Delta:        result.ThinkingText,
+			}
+			c.Writer.WriteString("event: response.reasoning_text.delta\ndata: " + reasoningEvt.String() + "\n\n")
+		}
+
+		// 正文增量
+		if result.Text != "" {
+			if !ttftSet {
+				ttftSet = true
+				ttftMs = time.Since(startTime).Milliseconds()
+			}
+			textEvt := officialtypes.ResponsesTextDeltaEvent{
+				Type:         "response.output_text.delta",
+				ItemID:       messageItemID,
+				OutputIndex:  1,
+				ContentIndex: 0,
+				Delta:        result.Text,
+			}
+			c.Writer.WriteString("event: response.output_text.delta\ndata: " + textEvt.String() + "\n\n")
+		}
+
+		if flusher != nil {
+			flusher.Flush()
+		}
+
+		parentMessageID := result.ParentMessageID
+		continue_info = result.Continue
+		if continue_info != nil {
+			parentMessageID = continue_info.ParentID
+		}
+		clientState.NoteTurnResult(result.ConversationID, parentMessageID)
+		if result.ConversationID != "" {
+			conversationID = result.ConversationID
+			h.sessions.Register(conversationID, clientState)
+		}
+		if continue_info == nil {
+			break
+		}
+		translated_request.Messages = nil
+		translated_request.Action = "continue"
+		translated_request.ConversationID = continue_info.ConversationID
+		translated_request.ParentMessageID = continue_info.ParentID
+
+		response, wsConn, _, _, err = conversationClientOrder(&client, account, translated_request, proxyUrl, true, clientState, h.accountPool)
+		if err != nil {
+			c.Writer.WriteString("event: response.failed\ndata: " + responsesFailedEvent(err.Error()) + "\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		defer response.Body.Close()
+		if chatgpt.Handle_request_error(c, response) {
+			if wsConn != nil {
+				wsConn.Close()
+				wsConn = nil
+			}
+			c.Writer.WriteString("event: response.failed\ndata: " + responsesFailedEvent("upstream error") + "\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+	}
+
+	// output_item.done (reasoning)
+	c.Writer.WriteString("event: response.output_item.done\ndata: " + responsesOutputItemDoneEvent(0, reasoningItemID, "reasoning", full_thinking) + "\n\n")
+	// output_item.done (message)
+	c.Writer.WriteString("event: response.output_item.done\ndata: " + responsesOutputItemDoneEvent(1, messageItemID, "message", full_response) + "\n\n")
+
+	output_tokens := util.CountToken(full_response)
+	reasoning_tokens := util.CountToken(full_thinking)
+	responsesResponse := officialtypes.NewResponsesResponse(full_response, full_thinking, input_tokens, output_tokens, reasoning_tokens, cachedTokens, cacheWriteTokens, reqModel)
+	// 在 response.completed 事件里附带 timing（HTTP headers 在首次 Flush 后不可写）
+	responsesResponse.MsSinceStart = time.Since(startTime).Milliseconds()
+	if ttftSet {
+		responsesResponse.MsTTFT = ttftMs
+	}
+	// response.completed
+	c.Writer.WriteString("event: response.completed\ndata: " + responsesCompletedEvent(responsesResponse) + "\n\n")
+	c.Writer.WriteString("data: [DONE]\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
 }
+
+// writeTimingHeader 在非流式响应中设置 timing 头部（仅非流式路径使用）。
 
 func (h *ChatHandler) Files(c *gin.Context) {
 	account, _, err := resolveAccount(c, h.accountPool, h.cfg, true)

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -12,6 +12,7 @@ import (
 	"aurora/internal/accounts"
 	"aurora/internal/chatgpt"
 	"aurora/internal/config"
+	"aurora/internal/httpstream"
 	"aurora/internal/toolcall"
 	chatgpt_types "aurora/typings/chatgpt"
 	officialtypes "aurora/typings/official"
@@ -143,6 +144,24 @@ func (h *ChatHandler) Nightmare(c *gin.Context) {
 	var stopSent bool
 	pingSent := false
 
+	// 记录请求开始时间，用于 TTFT / total-time 计时
+	startTime := time.Now()
+	ttftSet := false
+	var ttftMs int64
+
+	// 提取 instructions / input 用于缓存模拟（与 Responses 路径一致）
+	var instructions string
+	var inputTextParts []string
+	for _, msg := range original_request.Messages {
+		if msg.Role == "system" {
+			instructions += msg.Text()
+		} else {
+			inputTextParts = append(inputTextParts, msg.Text())
+		}
+	}
+	inputText := strings.Join(inputTextParts, "\n")
+	cacheWriteTokens, cachedTokens := RecordCache(translated_request.ConversationID, instructions, inputText)
+
 	if !h.cfg.StreamMode {
 		original_request.Stream = false
 	}
@@ -164,6 +183,11 @@ func (h *ChatHandler) Nightmare(c *gin.Context) {
 		continue_info = result.Continue
 		full_response += result.Text
 		full_thinking += result.ThinkingText
+		// 首个输出 token 到达时记录 TTFT（text chunk 已在 HandlerDetailedWithOptions 内写出）
+		if result.Text != "" && !ttftSet {
+			ttftSet = true
+			ttftMs = time.Since(startTime).Milliseconds()
+		}
 		if result.ConversationID != "" {
 			conversationID = result.ConversationID
 			h.sessions.Register(conversationID, clientState)
@@ -226,20 +250,8 @@ func (h *ChatHandler) Nightmare(c *gin.Context) {
 	} else {
 		if original_request.StreamOptions != nil && original_request.StreamOptions.IncludeUsage {
 			output_tokens := util.CountToken(full_response)
-			usageChunk := officialtypes.ChatCompletionChunk{
-				ID:      "chatcmpl-QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
-				Object:  "chat.completion.chunk",
-				Created: 0,
-				Model:   reqModel,
-				Choices: []officialtypes.Choices{},
-				Usage: &officialtypes.StreamUsage{
-					PromptTokens:     input_tokens,
-					CompletionTokens: output_tokens,
-					TotalTokens:      input_tokens + output_tokens,
-				},
-			}
-			c.Writer.WriteString("data: " + usageChunk.String() + "\n\n")
-			c.Writer.Flush()
+			msSinceStart := time.Since(startTime).Milliseconds()
+			httpstream.WriteUsageChunk(c, reqModel, input_tokens, output_tokens, cachedTokens, cacheWriteTokens, msSinceStart, ttftMs, ttftSet)
 		}
 		writeChatCompletionStreamDone(c, stopSent, reqModel, conversationID)
 	}

--- a/internal/handler/shared.go
+++ b/internal/handler/shared.go
@@ -288,3 +288,74 @@ func appendToolDebugLog(path string, attempt int, text string, calls []officialt
 	callsJSON, _ := json.Marshal(calls)
 	fmt.Fprintf(f, "\n=== attempt %d ===\ntext: %s\ncalls: %s\n", attempt, text, string(callsJSON))
 }
+
+// ── Responses 流式事件构造器 ──
+
+func responsesCreatedEvent(respID, model string) string {
+	evt := map[string]interface{}{
+		"type": "response.created",
+		"response": map[string]interface{}{
+			"id": respID, "object": "response", "created_at": time.Now().Unix(),
+			"model": model, "status": "in_progress",
+		},
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}
+
+func responsesOutputItemAddedEvent(outputIndex int, itemID, itemType string) string {
+	evt := map[string]interface{}{
+		"type": "response.output_item.added",
+		"output_index": outputIndex,
+		"item": map[string]interface{}{
+			"id": itemID, "type": itemType, "status": "in_progress",
+		},
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}
+
+func responsesOutputItemDoneEvent(outputIndex int, itemID, itemType, text string) string {
+	item := map[string]interface{}{
+		"id": itemID, "type": itemType, "status": "completed",
+	}
+	if itemType == "message" {
+		item["role"] = "assistant"
+		item["content"] = []map[string]interface{}{
+			{"type": "output_text", "text": text},
+		}
+	} else if itemType == "reasoning" {
+		item["content"] = []map[string]interface{}{
+			{"type": "reasoning_text", "text": text},
+		}
+	}
+	evt := map[string]interface{}{
+		"type":         "response.output_item.done",
+		"output_index": outputIndex,
+		"item":         item,
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}
+
+func responsesFailedEvent(msg string) string {
+	evt := map[string]interface{}{
+		"type": "response.failed",
+		"response": map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": msg, "type": "server_error",
+			},
+		},
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}
+
+func responsesCompletedEvent(resp officialtypes.ResponsesResponse) string {
+	evt := map[string]interface{}{
+		"type":     "response.completed",
+		"response": resp,
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}

--- a/internal/httpstream/stream.go
+++ b/internal/httpstream/stream.go
@@ -76,7 +76,9 @@ func WriteChatCompletionDone(c *gin.Context, stopSent bool, model string, conver
 }
 
 // WriteUsageChunk 写入 token usage 的 SSE chunk。
-func WriteUsageChunk(c *gin.Context, model string, inputTokens, outputTokens int) {
+// cachedTokens / cacheWriteTokens 用于填充 prompt_tokens_details（缓存命中/写入 token 数）。
+// msSinceStart / msTTFT 为耗时信息（毫秒），嵌入 chunk 的元字段（HTTP headers 在首次 Flush 后不可写）。
+func WriteUsageChunk(c *gin.Context, model string, inputTokens, outputTokens, cachedTokens, cacheWriteTokens int, msSinceStart, msTTFT int64, ttftSet bool) {
 	chunk := map[string]interface{}{
 		"id":      "chatcmpl-QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
 		"object":  "chat.completion.chunk",
@@ -87,7 +89,15 @@ func WriteUsageChunk(c *gin.Context, model string, inputTokens, outputTokens int
 			"prompt_tokens":     inputTokens,
 			"completion_tokens": outputTokens,
 			"total_tokens":      inputTokens + outputTokens,
+			"prompt_tokens_details": map[string]interface{}{
+				"cached_tokens":      cachedTokens,
+				"cache_write_tokens": cacheWriteTokens,
+			},
 		},
+		"ms_since_start": msSinceStart,
+	}
+	if ttftSet {
+		chunk["ms_ttft"] = msTTFT
 	}
 	data, _ := json.Marshal(chunk)
 	c.Writer.WriteString("data: " + string(data) + "\n\n")

--- a/typings/official/request.go
+++ b/typings/official/request.go
@@ -390,7 +390,9 @@ type ResponseFormatText struct {
 
 // ReasoningConfig 对应 Responses API 的 reasoning 参数。
 type ReasoningConfig struct {
-	Effort string `json:"effort,omitempty"` // "low" | "medium" | "high"
+	Effort  string `json:"effort,omitempty"`  // "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
+	Summary string `json:"summary,omitempty"` // "auto" | "concise" | "detailed"
+	Context string `json:"context,omitempty"` // "auto" | "current_turn" | "all_turns"
 }
 
 type responseInputMessage struct {

--- a/typings/official/response.go
+++ b/typings/official/response.go
@@ -258,13 +258,22 @@ type ResponsesResponse struct {
 	OutputText       string                `json:"output_text"`
 	Usage            ResponsesUsage        `json:"usage"`
 	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	// MsSinceStart / MsTTFT 是流式响应的耗时信息（毫秒），嵌入 response.completed 事件。
+	MsSinceStart     int64                 `json:"ms_since_start,omitempty"`
+	MsTTFT           int64                 `json:"ms_ttft,omitempty"`
 }
 
 type ResponsesTextDeltaEvent struct {
-	Type         string `json:"type"`
-	Delta        string `json:"delta"`
+	Type         string `json:"type"` // "response.output_text.delta"
+	ItemID       string `json:"item_id,omitempty"`
 	OutputIndex  int    `json:"output_index"`
 	ContentIndex int    `json:"content_index"`
+	Delta        string `json:"delta"`
+}
+
+func (e ResponsesTextDeltaEvent) String() string {
+	b, _ := json.Marshal(e)
+	return string(b)
 }
 
 type ResponsesCreatedEvent struct {

--- a/typings/official/response.go
+++ b/typings/official/response.go
@@ -1,6 +1,9 @@
 package official
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 type ChatCompletionChunk struct {
 	ID             string                 `json:"id"`
@@ -246,28 +249,15 @@ func derefString(p *string) string {
 }
 
 type ResponsesResponse struct {
-	ID         string            `json:"id"`
-	Object     string            `json:"object"`
-	CreatedAt  int64             `json:"created_at"`
-	Status     string            `json:"status"`
-	Model      string            `json:"model"`
-	Output     []ResponsesOutput `json:"output"`
-	OutputText string            `json:"output_text"`
-	Usage      usage             `json:"usage"`
-}
-
-type ResponsesOutput struct {
-	ID      string             `json:"id"`
-	Type    string             `json:"type"`
-	Status  string             `json:"status"`
-	Role    string             `json:"role"`
-	Content []ResponsesContent `json:"content"`
-}
-
-type ResponsesContent struct {
-	Type        string        `json:"type"`
-	Text        string        `json:"text"`
-	Annotations []interface{} `json:"annotations"`
+	ID               string                `json:"id"`
+	Object           string                `json:"object"`
+	CreatedAt        int64                 `json:"created_at"`
+	Status           string                `json:"status"`
+	Model            string                `json:"model"`
+	Output           []ResponsesOutputItem `json:"output"`
+	OutputText       string                `json:"output_text"`
+	Usage            ResponsesUsage        `json:"usage"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
 }
 
 type ResponsesTextDeltaEvent struct {
@@ -287,38 +277,55 @@ type ResponsesCompletedEvent struct {
 	Response ResponsesResponse `json:"response"`
 }
 
-func NewResponsesResponse(text string, inputTokens, outputTokens int, model string) ResponsesResponse {
+func NewResponsesResponse(text, reasoning string, inputTokens, outputTokens, reasoningTokens int, cachedTokens, cacheWriteTokens int, model string) ResponsesResponse {
 	if model == "" {
 		model = "auto"
 	}
-	return ResponsesResponse{
-		ID:         "resp_QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
-		Object:     "response",
-		CreatedAt:  int64(0),
-		Status:     "completed",
-		Model:      model,
-		OutputText: text,
-		Usage: usage{
-			PromptTokens:     inputTokens,
-			CompletionTokens: outputTokens,
-			TotalTokens:      inputTokens + outputTokens,
+	resp := ResponsesResponse{
+		ID:               "resp_QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
+		Object:           "response",
+		CreatedAt:        time.Now().Unix(),
+		Status:           "completed",
+		Model:            model,
+		OutputText:       text,
+		ReasoningContent: reasoning,
+		Usage: ResponsesUsage{
+			InputTokens: inputTokens,
+			InputTokensDetails: ResponsesInputTokensDetails{
+				CachedTokens:     cachedTokens,
+				CacheWriteTokens: cacheWriteTokens,
+			},
+			OutputTokens: outputTokens,
+			OutputTokensDetails: ResponsesOutputTokensDetails{
+				ReasoningTokens: reasoningTokens,
+			},
+			TotalTokens: inputTokens + outputTokens,
 		},
-		Output: []ResponsesOutput{
+		Output: []ResponsesOutputItem{
 			{
 				ID:     "msg_QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
 				Type:   "message",
 				Status: "completed",
 				Role:   "assistant",
-				Content: []ResponsesContent{
-					{
-						Type:        "output_text",
-						Text:        text,
-						Annotations: []interface{}{},
-					},
+				Content: []ResponsesContentPart{
+					{Type: "output_text", Text: text},
 				},
 			},
 		},
 	}
+	if reasoning != "" {
+		resp.Output = append([]ResponsesOutputItem{
+			{
+				ID:     "rs_QXlha2FBbmROaXhpZUFyZUF3ZXNvbWUK",
+				Type:   "reasoning",
+				Status: "completed",
+				Content: []ResponsesContentPart{
+					{Type: "reasoning_text", Text: reasoning},
+				},
+			},
+		}, resp.Output...)
+	}
+	return resp
 }
 
 func ResponsesTextDelta(text string) string {
@@ -349,6 +356,62 @@ func ResponsesCompleted(response ResponsesResponse) string {
 	}
 	resp, _ := json.Marshal(event)
 	return string(resp)
+}
+
+// ── OpenAI Responses API 扩展类型（对齐 openai-node responses.ts） ──
+
+// ResponsesUsage 对齐 OpenAI ResponseUsage。
+type ResponsesUsage struct {
+	InputTokens         int                        `json:"input_tokens"`
+	InputTokensDetails  ResponsesInputTokensDetails  `json:"input_tokens_details"`
+	OutputTokens        int                        `json:"output_tokens"`
+	OutputTokensDetails ResponsesOutputTokensDetails `json:"output_tokens_details"`
+	TotalTokens         int                        `json:"total_tokens"`
+}
+
+type ResponsesInputTokensDetails struct {
+	CachedTokens     int `json:"cached_tokens"`
+	CacheWriteTokens int `json:"cache_write_tokens"`
+}
+
+type ResponsesOutputTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
+}
+
+// ResponsesOutputItem 对齐 OpenAI ResponseOutputItem 的最小形态。
+type ResponsesOutputItem struct {
+	ID      string                 `json:"id"`
+	Type    string                 `json:"type"` // "message" | "reasoning"
+	Status  string                 `json:"status,omitempty"`
+	Role    string                 `json:"role,omitempty"`
+	Content []ResponsesContentPart `json:"content"`
+}
+
+type ResponsesContentPart struct {
+	Type string `json:"type"` // "output_text" | "reasoning_text"
+	Text string `json:"text"`
+}
+
+// ResponsesReasoningItem 用于最终 output 数组里的思维链项。
+type ResponsesReasoningItem struct {
+	ID      string                 `json:"id"`
+	Type    string                 `json:"type"` // "reasoning"
+	Status  string                 `json:"status"`
+	Content []ResponsesContentPart `json:"content"`
+}
+
+// ResponsesReasoningDeltaEvent 流式思维链事件。
+type ResponsesReasoningDeltaEvent struct {
+	Type         string `json:"type"` // "response.reasoning_text.delta"
+	ItemID       string `json:"item_id"`
+	OutputIndex  int    `json:"output_index"`
+	ContentIndex int    `json:"content_index"`
+	Delta        string `json:"delta"`
+}
+
+func (e ResponsesReasoningDeltaEvent) String() string {
+	b, _ := json.Marshal(e)
+	return string(b)
 }
 
 type OpenAIAccessTokenWithSession struct {

--- a/typings/official/response_test.go
+++ b/typings/official/response_test.go
@@ -2,6 +2,7 @@ package official
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +51,40 @@ func TestNewChatCompletionWithMetadata(t *testing.T) {
 	}
 	if sentinel[0].(map[string]interface{})["event"] != "artifact" {
 		t.Fatalf("first sentinel = %#v, want artifact", sentinel[0])
+	}
+}
+
+func TestNewResponsesResponseWithReasoning(t *testing.T) {
+	resp := NewResponsesResponse("hello", "thinking...", 100, 50, 30, 80, 20, "auto")
+	if resp.Object != "response" {
+		t.Fatalf("object = %q, want response", resp.Object)
+	}
+	if resp.OutputText != "hello" {
+		t.Fatalf("output_text = %q, want hello", resp.OutputText)
+	}
+	b, _ := json.Marshal(resp)
+	s := string(b)
+	for _, want := range []string{
+		`"input_tokens":100`,
+		`"cached_tokens":80`,
+		`"cache_write_tokens":20`,
+		`"reasoning_tokens":30`,
+		`"type":"reasoning"`,
+		`"reasoning_text"`,
+		`"reasoning_content":"thinking..."`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("missing %q in %s", want, s)
+		}
+	}
+}
+
+func TestNewResponsesResponseWithoutReasoning(t *testing.T) {
+	resp := NewResponsesResponse("hi", "", 10, 5, 0, 0, 0, "auto")
+	if len(resp.Output) != 1 {
+		t.Fatalf("output len = %d, want 1", len(resp.Output))
+	}
+	if resp.Output[0].Type != "message" {
+		t.Fatalf("first output type = %q, want message", resp.Output[0].Type)
 	}
 }


### PR DESCRIPTION
## 概要

对齐 OpenAI 官方 Responses API 契约（基于 openai-node SDK + codex-cli 源码逆向），让 Codex CLI 能作为客户端调用 aurora。

## 主要改动

- **Responses 真流式**：完整事件序列 `created → output_item.added → reasoning_text.delta → output_text.delta → output_item.done → completed`
- **思维链透传**：`response.reasoning_text.delta` 流式 + 最终 `reasoning` 输出项
- **缓存模拟**：移植 claude2api 的 `cacheTracker`（指纹 + 5分钟 TTL），输出 OpenAI `input_tokens_details`
- **effort 7 档映射**：`none/minimal→low`, `medium→medium`, `xhigh/max→high`
- **timing**：`response.completed` 事件附带 `ms_since_start` / `ms_ttft`
- **chat 路径补齐**：同样加 `prompt_tokens_details` + timing

## 关键设计决策

- 缓存为**模拟值**（ChatGPT 上游不返回真实 cache），文档已注明
- timing 嵌入 SSE 事件而非 HTTP header（Go 在首次 Flush 后 header 不可写）
- 事件名/字段名严格对齐 openai-node SDK

## 测试

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./typings/... ./internal/handler/... ./internal/httpstream/... ./conversion/...` ✅ (5/5)