### PR TITLE
fix(bootstrap): session_token 交换全程使用 std client 并持久化轮换后的令牌

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -11,6 +11,8 @@ import (
 	"aurora/internal/config"
 	"aurora/internal/handler"
 	"aurora/internal/proxy"
+	"aurora/httpclient"
+	bogdanfinn "aurora/httpclient/bogdanfinn"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -198,7 +200,12 @@ func exchangeRefreshToken(acct *accounts.Account) bool {
 	return false
 }
 
-// exchangeSessionToken 用 session_token 换 access_token，使用账号自身的 Client（已绑定代理）
+// exchangeSessionToken 用 session_token 换 access_token。
+// 必须全程使用普通 std client：指纹 TLS client 请求 /api/auth/session 时，
+// 即使响应被 Cloudflare 拦截无法解析，OpenAI 端也已消费掉一次性轮换的会话令牌，
+// 任何后续重试都会拿到匿名空会话。
+// OpenAI 会话令牌为一次性轮换，成功后必须把新令牌写回文件并更新账号，
+// 否则重启加载与 10 分钟健康续期都会拿已消费的旧令牌。
 func exchangeSessionToken(acct *accounts.Account) bool {
 	if acct.SessionToken == "" {
 		return false
@@ -206,25 +213,62 @@ func exchangeSessionToken(acct *accounts.Account) bool {
 	if acct.Client == nil {
 		_ = acct.InitClient()
 	}
-	result, _, err := chatgpt.GETTokenForSessionToken(acct.Client, acct.SessionToken, "")
-	if err != nil {
+	fetch := func(client httpclient.AuroraHttpClient) (string, string) {
+		result, _, err := chatgpt.GETTokenForSessionToken(client, acct.SessionToken, "")
+		if err != nil {
+			return "", ""
+		}
+		if r, ok := result.(interface {
+			GetAccessToken() string
+			GetSessionToken() string
+		}); ok {
+			return r.GetAccessToken(), r.GetSessionToken()
+		}
+		if data, ok := result.(map[string]interface{}); ok {
+			accessToken, _ := data["accessToken"].(string)
+			sessionToken, _ := data["session_token"].(string)
+			return accessToken, sessionToken
+		}
+		return "", ""
+	}
+	accessToken, rotated := fetch(bogdanfinn.NewStdClient())
+	if accessToken == "" {
 		return false
 	}
-	// 优先尝试 struct 形式 (*OpenAIAccessTokenWithSession)
-	if r, ok := result.(interface{ GetAccessToken() string }); ok {
-		if at := r.GetAccessToken(); at != "" {
-			acct.Token = at
-			return true
+	acct.Token = accessToken
+	if rotated != "" && rotated != acct.SessionToken {
+		oldToken := acct.SessionToken
+		acct.SessionToken = rotated
+		persistRotatedSessionToken(oldToken, rotated, acct.TeamUserID)
+	}
+	return true
+}
+
+// persistRotatedSessionToken 将轮换得到的新 session token 写回 session_tokens.txt，
+// 只替换旧令牌所在行，保留其它账号的行；文件不存在时直接写入。
+func persistRotatedSessionToken(oldToken, newToken, teamID string) {
+	value := newToken
+	if teamID != "" {
+		value += ":" + teamID
+	}
+	data, err := os.ReadFile("session_tokens.txt")
+	if err != nil {
+		_ = os.WriteFile("session_tokens.txt", []byte(value+"\n"), 0644)
+		return
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\r\n"), "\n")
+	replaced := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), oldToken) {
+			lines[i] = value
+			replaced = true
+			break
 		}
 	}
-	// fallback: map[string]interface{}
-	if data, ok := result.(map[string]interface{}); ok {
-		if accessToken, ok := data["accessToken"].(string); ok && accessToken != "" {
-			acct.Token = accessToken
-			return true
-		}
+	if !replaced {
+		lines = append(lines, value)
 	}
-	return false
+	_ = os.WriteFile("session_tokens.txt", []byte(strings.Join(lines, "\n")+"\n"), 0644)
 }
 
 // loadProxyList 从 proxies.txt / PROXY_URL / http_proxy 加载代理列表

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -2,17 +2,20 @@ package bootstrap
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
+	"aurora/httpclient"
+	bogdanfinn "aurora/httpclient/bogdanfinn"
 	"aurora/internal/accounts"
 	"aurora/internal/browserfp"
 	"aurora/internal/chatgpt"
 	"aurora/internal/config"
 	"aurora/internal/handler"
 	"aurora/internal/proxy"
-	"aurora/httpclient"
-	bogdanfinn "aurora/httpclient/bogdanfinn"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -99,6 +102,7 @@ func Init() (*App, error) {
 
 		acct := accounts.CreateAccount("", accounts.TypeFree, profiles)
 		acct.SessionToken = t.Token
+		acct.TeamUserID = t.TeamID
 		acct.Proxy = proxyPool.Allocate()
 		// 立即交换一次获取 access_token
 		if exchangeSessionToken(acct) {
@@ -210,11 +214,8 @@ func exchangeSessionToken(acct *accounts.Account) bool {
 	if acct.SessionToken == "" {
 		return false
 	}
-	if acct.Client == nil {
-		_ = acct.InitClient()
-	}
 	fetch := func(client httpclient.AuroraHttpClient) (string, string) {
-		result, _, err := chatgpt.GETTokenForSessionToken(client, acct.SessionToken, "")
+		result, _, err := chatgpt.GETTokenForSessionToken(client, acct.SessionToken, acct.Proxy)
 		if err != nil {
 			return "", ""
 		}
@@ -244,22 +245,33 @@ func exchangeSessionToken(acct *accounts.Account) bool {
 	return true
 }
 
+// sessionTokenFileMu 保护 session_tokens.txt 的读-改-写，避免并发续期互相覆盖。
+var sessionTokenFileMu sync.Mutex
+
 // persistRotatedSessionToken 将轮换得到的新 session token 写回 session_tokens.txt，
 // 只替换旧令牌所在行，保留其它账号的行；文件不存在时直接写入。
+// 写入经临时文件 + rename，避免中途失败把整个凭据文件截断。
 func persistRotatedSessionToken(oldToken, newToken, teamID string) {
+	const path = "session_tokens.txt"
+
 	value := newToken
 	if teamID != "" {
 		value += ":" + teamID
 	}
-	data, err := os.ReadFile("session_tokens.txt")
+
+	sessionTokenFileMu.Lock()
+	defer sessionTokenFileMu.Unlock()
+
+	data, err := os.ReadFile(path)
 	if err != nil {
-		_ = os.WriteFile("session_tokens.txt", []byte(value+"\n"), 0644)
+		writeFileAtomic(path, []byte(value+"\n"))
 		return
 	}
 	lines := strings.Split(strings.TrimRight(string(data), "\r\n"), "\n")
 	replaced := false
 	for i, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), oldToken) {
+		// 与 accounts.LoadTokensFromFile 一致：token 在 ":" 前，其后为 team_id
+		if strings.TrimSpace(strings.SplitN(strings.TrimSpace(line), ":", 2)[0]) == oldToken {
 			lines[i] = value
 			replaced = true
 			break
@@ -268,7 +280,35 @@ func persistRotatedSessionToken(oldToken, newToken, teamID string) {
 	if !replaced {
 		lines = append(lines, value)
 	}
-	_ = os.WriteFile("session_tokens.txt", []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	writeFileAtomic(path, []byte(strings.Join(lines, "\n")+"\n"))
+}
+
+// writeFileAtomic 先写同目录临时文件再 rename，保证凭据文件不会被写成半截。
+func writeFileAtomic(path string, data []byte) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp")
+	if err != nil {
+		_ = os.WriteFile(path, data, 0644)
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	// Windows 下 rename 到已存在的文件需要先移除目标
+	if runtime.GOOS == "windows" {
+		_ = os.Remove(path)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		_ = os.WriteFile(path, data, 0644)
+	}
 }
 
 // loadProxyList 从 proxies.txt / PROXY_URL / http_proxy 加载代理列表

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,124 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"aurora/internal/accounts"
+)
+
+// chdirTemp 把工作目录切到临时目录，persistRotatedSessionToken 用的是相对路径。
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+	return dir
+}
+
+func readTokenFile(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "session_tokens.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestPersistRotatedSessionTokenReplacesOnlyMatchingLine(t *testing.T) {
+	dir := chdirTemp(t)
+	if err := os.WriteFile("session_tokens.txt", []byte("aaa\nbbb\nccc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	persistRotatedSessionToken("bbb", "bbb-new", "")
+
+	if got, want := readTokenFile(t, dir), "aaa\nbbb-new\nccc\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPersistRotatedSessionTokenPreservesTeamID(t *testing.T) {
+	dir := chdirTemp(t)
+	if err := os.WriteFile("session_tokens.txt", []byte("aaa:team-a\nbbb\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	persistRotatedSessionToken("aaa", "aaa-new", "team-a")
+
+	if got, want := readTokenFile(t, dir), "aaa-new:team-a\nbbb\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// 旧实现用 HasPrefix，短 token 会错误命中以它为前缀的另一行。
+func TestPersistRotatedSessionTokenDoesNotMatchOnPrefix(t *testing.T) {
+	dir := chdirTemp(t)
+	if err := os.WriteFile("session_tokens.txt", []byte("abcdef\nabc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	persistRotatedSessionToken("abc", "abc-new", "")
+
+	if got, want := readTokenFile(t, dir), "abcdef\nabc-new\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPersistRotatedSessionTokenAppendsWhenAbsent(t *testing.T) {
+	dir := chdirTemp(t)
+	if err := os.WriteFile("session_tokens.txt", []byte("aaa\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	persistRotatedSessionToken("zzz", "zzz-new", "")
+
+	if got, want := readTokenFile(t, dir), "aaa\nzzz-new\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPersistRotatedSessionTokenCreatesFileWhenMissing(t *testing.T) {
+	dir := chdirTemp(t)
+
+	persistRotatedSessionToken("old", "new", "team-x")
+
+	if got, want := readTokenFile(t, dir), "new:team-x\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// 轮换写回后重新加载，应能读到新令牌（重启持久性）。
+func TestRotatedTokenSurvivesReload(t *testing.T) {
+	chdirTemp(t)
+	if err := os.WriteFile("session_tokens.txt", []byte("old:team-a\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	persistRotatedSessionToken("old", "rotated", "team-a")
+
+	loaded := accounts.LoadTokensFromFile("session_tokens.txt")
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(loaded))
+	}
+	if loaded[0].Token != "rotated" {
+		t.Errorf("token = %q, want %q", loaded[0].Token, "rotated")
+	}
+	if loaded[0].TeamID != "team-a" {
+		t.Errorf("teamID = %q, want %q", loaded[0].TeamID, "team-a")
+	}
+}
+
+func TestExchangeSessionTokenNoopWithoutToken(t *testing.T) {
+	acct := &accounts.Account{}
+	if exchangeSessionToken(acct) {
+		t.Error("expected false for empty session token")
+	}
+}


### PR DESCRIPTION
## 问题

`session_tokens.txt` 中的账号在启动时永远加载失败，`/v1/chat/completions` 返回 `no available account of the requested type`；即使令牌本身有效也是如此。

## 根因

**1. 交换请求会被静默烧掉令牌。** 启动加载与 10 分钟健康续期都用账号的指纹 TLS client 调 `/api/auth/session`。该端点对指纹 client 的请求经常被 Cloudflare 拦截、响应无法解析——但 OpenAI 服务端**已经消费掉一次性轮换的 session token**。于是任何后续重试（包括换 std client 重试）拿到的都是匿名空会话（`accessToken` 为空），账号被标记 `StatusExpired`。

**2. 轮换结果被丢弃。** `GETTokenForSessionToken` 明明从 Set-Cookie 里解析出了新 session token，但 `exchangeSessionToken` 只取 access token：新令牌既不写回 `session_tokens.txt`，也不更新 `acct.SessionToken`。由于旧令牌已被消费，重启加载和健康续期都会永远拿失效令牌。

## 修复（`internal/bootstrap/bootstrap.go`）

- 交换全程使用 `bogdanfinn.NewStdClient()`（与 `/auth/session` handler 中已验证可用的路径一致），不再先试指纹 client；
- 交换成功后更新 `acct.SessionToken`，并把新令牌写回 `session_tokens.txt`——只替换旧令牌所在行，保留其它账号的行，兼容 `token:team_id` 格式；
- 保持 map 解析 fallback 不变。

## 验证

- Windows 11 + ChatGPT Plus 账号：修复前 session 账号加载必失败；修复后启动交换成功，`gpt-5-5-instant` 等模型补全正常（响应含 `conversation_id`，走 web conversation 链路）。
- 重启 aurora 后文件中的令牌可再次认证（重启持久性验证通过）。
- `go build ./...` 与 `go vet` 通过。

EN summary: session-token accounts always failed to load because the fingerprint-TLS-client request to `/api/auth/session` gets Cloudflare-blocked while OpenAI still consumes the one-time rotated session token server-side (silently burning it), and the rotated token returned via Set-Cookie was never persisted nor written back to `acct.SessionToken`. Fix: do the exchange with the std client only and persist the rotated token back to `session_tokens.txt` (replacing only the old token's line).